### PR TITLE
fix: explicitly add recvonly transceivers are needed for Safari

### DIFF
--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -55,7 +55,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   document.querySelector<HTMLButtonElement>("#play").addEventListener("click", async () => {
     const channelUrl = input.value;
-    const player = new WebRTCPlayer({ video: video, type: type, iceServers: iceServers });
+    const player = new WebRTCPlayer({ video: video, type: type, iceServers: iceServers, debug: true });
     await player.load(new URL(channelUrl));
   });
 });

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -24,7 +24,7 @@ export class BaseAdapter {
     this.onIceCandidateFn = this.onIceCandidate.bind(this);
   }
 
-  private log(...args: any[]) {
+  protected log(...args: any[]) {
     if (this.debug) {
       console.log("WebRTC-player", ...args);
     }
@@ -81,6 +81,9 @@ export class BaseAdapter {
   }
 
   async connect(opts?: AdapterConnectOptions) {
+    this.localPeer.addTransceiver("video", { direction: "recvonly" });
+    this.localPeer.addTransceiver("audio", { direction: "recvonly" });
+
     const offer = await this.localPeer.createOffer({
       offerToReceiveAudio: true,
       offerToReceiveVideo: true,


### PR DESCRIPTION
This PR resolves #4 by explicitly adding recvonly RTPTransceivers which seems to be required for Safari