### PR TITLE
feat: remove feedback data channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ ICE_SERVERS=turn:<USERNAME>:<SECRET>@turn.eyevinn.technology:3478 npm run dev
   iceServers: RTCIceServer[]; // ICE server config
   type: string; // type of adapter (see below for a list of included adapters below)
   adapterFactory: AdapterFactoryFunction; // provide a custom adapter factory when adapter type is "custom"
-  createDataChannels?: string[]; // array of datachannel labels to create 
 }
 ```
 

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -61,26 +61,9 @@ window.addEventListener("DOMContentLoaded", async () => {
       video: video, 
       type: type, 
       iceServers: iceServers, 
-      debug: true,
-      createDataChannels: [ "reactions" ] });
+      debug: true
+    });
 
     await player.load(new URL(channelUrl));
-
-    player.on("message", (message) => {
-      console.log(message);
-    });
-  });
-
-  const heartButton = document.querySelector<HTMLButtonElement>("#heart");
-  heartButton.addEventListener("click", async () => {
-    heartButton.classList.toggle("animate");
-    player.send("reactions", {
-      event: "reaction",
-      reaction: "like",
-    });
-
-    setTimeout(() => { 
-      heartButton.classList.remove("animate");
-    }, 5000);
   });
 });

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,28 +22,6 @@
       button {
         margin: 4px;
       }
-      button#heart {
-        background: url('https://s3-us-west-2.amazonaws.com/s.cdpn.io/66955/web_heart_animation.png');
-        background-size: 2900%;
-        background-repeat: no-repeat;
-        background-position: left;
-        position: relative;
-        z-index: 10;
-        top: 50px;
-        width: 50px;
-        height: 50px;
-      }
-      button#heart.animate {
-        animation: heart-burst .8s steps(28) forwards; 
-      }
-      @keyframes heart-burst {
-        0% {
-          background-position: left
-        }
-        100% {
-          background-position: right
-        }
-      }
     </style>
   </head>
   <body>
@@ -58,7 +36,6 @@
         <button id="play">Play</button>
       </div>
       <div id="videocontainer">
-        <button id="heart"></button>
         <video autoplay muted controls></video>
       </div>
     </section>

--- a/src/adapters/Adapter.ts
+++ b/src/adapters/Adapter.ts
@@ -5,7 +5,6 @@ export interface AdapterConnectOptions {
 }
 
 export interface Adapter{
-    setupDataChannels(labels: string[]): RTCDataChannel[];
     enableDebug();
     getPeer() : RTCPeerConnection;
     connect(opts?: AdapterConnectOptions);

--- a/src/adapters/EyevinnAdapter.ts
+++ b/src/adapters/EyevinnAdapter.ts
@@ -23,11 +23,6 @@ export class EyevinnAdapter implements Adapter {
     this.localPeer.onicecandidate = this.onIceCandidate.bind(this);
   }
 
-  setupDataChannels(labels: string[]): RTCDataChannel[] {
-    const channels = labels.map(label => this.localPeer.createDataChannel(label));
-    return channels;
-  }
-
   enableDebug() {
     this.debug = true;
   }

--- a/src/adapters/WHPPAdapter.ts
+++ b/src/adapters/WHPPAdapter.ts
@@ -39,11 +39,6 @@ export class WHPPAdapter implements Adapter {
     this.localPeer.onicecandidate = this.onIceCandidate.bind(this);
   }
 
-  setupDataChannels(labels: string[]): RTCDataChannel[] {
-    const channels = labels.map(label => this.localPeer.createDataChannel(label));
-    return channels;
-  }
-
   enableDebug() {
     this.debug = true;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ interface WebRTCPlayerOptions {
   adapterFactory?: AdapterFactoryFunction;
   iceServers?: RTCIceServer[];
   debug?: boolean;
-  createDataChannels?: string[];
 }
 
 const RECONNECT_ATTEMPTS = 2;
@@ -22,8 +21,6 @@ export class WebRTCPlayer extends EventEmitter {
   private adapterFactory: AdapterFactoryFunction;
   private iceServers: RTCIceServer[];
   private debug: boolean;
-  private createDataChannels: string[];
-  private rtcDataChannels: RTCDataChannel[];
   private channelUrl: URL;
   private reconnectAttemptsLeft: number = RECONNECT_ATTEMPTS;
 
@@ -38,7 +35,6 @@ export class WebRTCPlayer extends EventEmitter {
       this.iceServers = opts.iceServers;
     }
     this.debug = !!opts.debug;
-    this.createDataChannels = opts.createDataChannels || [];
   }
 
   async load(channelUrl: URL) {
@@ -97,27 +93,8 @@ export class WebRTCPlayer extends EventEmitter {
         this.videoElement.srcObject = ev.streams[0];
       }
     };
-    if (this.createDataChannels) {
-      this.rtcDataChannels = adapter.setupDataChannels(this.createDataChannels);
-      this.rtcDataChannels.forEach(channel => {
-        channel.onmessage = (ev) => {
-          this.emit("message", ev.data);
-        }
-      });
-    }
+    
     await adapter.connect();
-  }
-
-  send(channelLabel: string, data: any) {
-    const rtcDataChannel = this.rtcDataChannels.find(channel => channel.label === channelLabel);
-    if (!rtcDataChannel) {
-      return;
-    }
-    if (rtcDataChannel.readyState !== "open") {
-      return;
-    }
-
-    rtcDataChannel.send(JSON.stringify(data));
   }
 
   mute() {


### PR DESCRIPTION
Because feedback messages from signalling server to clients over the data channel is unsupported when moving to a separate SFU, support for data channel messaging is removed. 