### PR TITLE
feat: emit peer connection events for connection failure & no-media

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export class WebRTCPlayer extends EventEmitter {
   private statsInterval: any;
   private statsTypeFilter: string;
   private msStatsInterval: number = 5000;
-  private detectMediaTimeout: boolean = false;
+  private detectMediaTimeout: boolean = true;
   private mediaTimeoutThreshold: number = 30000;
   private timeoutThresholdCounter: number = 0;
   private bytesReceived: number = 0;
@@ -143,6 +143,8 @@ export class WebRTCPlayer extends EventEmitter {
 
           if (this.timeoutThresholdCounter >= this.mediaTimeoutThreshold) {
             this.emit(Message.NO_MEDIA);
+            console.log("no-media");
+            this.timeoutThresholdCounter = 0;
           }
         }
         else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,10 @@ export class WebRTCPlayer extends EventEmitter {
     this.adapterFactory = opts.adapterFactory;
     this.statsTypeFilter = opts.statsTypeFilter;
     this.detectMediaTimeout = opts.detectTimeout;
-    this.mediaTimeoutThreshold = opts.timeoutThreshold;
+
+    if(opts.timeoutThreshold){
+      this.mediaTimeoutThreshold = opts.timeoutThreshold;
+    }
 
     this.iceServers = [{ urls: "stun:stun.l.google.com:19302" }];
     if (opts.iceServers) {
@@ -123,10 +126,6 @@ export class WebRTCPlayer extends EventEmitter {
           this.emit(`stats:${report.type}`, report);
         }
 
-        //remove before commit
-        this.detectMediaTimeout = true;
-        //
-
         if (this.detectMediaTimeout == true && report.type.match('inbound-rtp') ) { 
           this.emit(`stats:${report.type}`, report);
           bytesReceivedBlock += report.bytesReceived;
@@ -138,7 +137,7 @@ export class WebRTCPlayer extends EventEmitter {
         if(this.timeoutThresholdCounter >= this.mediaTimeoutThreshold)
         {
           this.emit('no-media');
-          console.log("no-media")
+          this.detectMediaTimeout = false;
         }
        
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export class WebRTCPlayer extends EventEmitter {
   private statsInterval: any;
   private statsTypeFilter: string;
   private msStatsInterval: number = 5000;
-  private detectMediaTimeout: boolean = true;
+  private detectMediaTimeout: boolean = false;
   private mediaTimeoutThreshold: number = 30000;
   private timeoutThresholdCounter: number = 0;
   private bytesReceived: number = 0;
@@ -143,7 +143,6 @@ export class WebRTCPlayer extends EventEmitter {
 
           if (this.timeoutThresholdCounter >= this.mediaTimeoutThreshold) {
             this.emit(Message.NO_MEDIA);
-            console.log("no-media");
             this.timeoutThresholdCounter = 0;
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,19 +121,20 @@ export class WebRTCPlayer extends EventEmitter {
           this.emit(`stats:${report.type}`, report);
         }
 
-        if (report.type.match('inbound-rtp')) {
+        if (this.detectMediaTimeout == true && report.lastPacketReceivedTimestamp >= this.mediaTimeoutThreshold && report.type.match('inbound-rtp') ) {
+
             this.emit(`stats:${report.type}`, report);
             bytesReceivedBlock += report.bytesReceived;
+
+            if (bytesReceivedBlock <= this.bytesReceived) {
+              this.emit('media reception ended');
+            }
+            else {
+              this.bytesReceived = bytesReceivedBlock;
+            }
         }
 
       });
-
-      if (bytesReceivedBlock <= this.bytesReceived) {
-        this.emit('media reception ended');
-      }
-      else {
-        this.bytesReceived = bytesReceivedBlock;
-      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,18 +73,6 @@ export class WebRTCPlayer extends EventEmitter {
 
   private async onConnectionStateChange(e) {
 
-    if (this.peer.connectionState === 'connected') {
-      const senders = await this.peer.getSenders();
-      if (senders) {
-        senders.forEach(sender => {
-          if (sender.track.readyState === 'ended') {
-            this.log('Track ended', e);
-            return;
-          }
-        });
-      }
-    }
-
     if (this.peer.connectionState === 'failed') {
       this.peer && this.peer.close();
 
@@ -123,6 +111,13 @@ export class WebRTCPlayer extends EventEmitter {
         if (report.type.match(this.statsTypeFilter)) {
           this.emit(`stats:${report.type}`, report);
         }
+
+        if (report.type.match('inbound-rtp')) {
+          if (report.bytesReceived === '0'){
+            this.emit(`stats:${report.type}`, report);
+          }
+        }
+
       });
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ interface WebRTCPlayerOptions {
   debug?: boolean;
   vmapUrl?: string;
   statsTypeFilter?: string; // regexp
+  detectTimeout?: boolean;
+  timeoutThreshold?: number;
 }
 
 const RECONNECT_ATTEMPTS = 2;
@@ -30,6 +32,8 @@ export class WebRTCPlayer extends EventEmitter {
   private adapter: Adapter;
   private statsInterval: any;
   private statsTypeFilter: string;
+  private detectMediaTimeout: boolean = false;
+  private mediaTimeoutThreshold: number = 30000;
   private bytesReceived: number = 0;
 
   constructor(opts: WebRTCPlayerOptions) {
@@ -38,6 +42,8 @@ export class WebRTCPlayer extends EventEmitter {
     this.adapterType = opts.type;
     this.adapterFactory = opts.adapterFactory;
     this.statsTypeFilter = opts.statsTypeFilter;
+    this.detectMediaTimeout = opts.detectTimeout;
+    this.mediaTimeoutThreshold = opts.timeoutThreshold;
 
     this.iceServers = [{ urls: "stun:stun.l.google.com:19302" }];
     if (opts.iceServers) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,11 +49,9 @@ export class WebRTCPlayer extends EventEmitter {
     this.adapterType = opts.type;
     this.adapterFactory = opts.adapterFactory;
     this.statsTypeFilter = opts.statsTypeFilter;
-    this.detectMediaTimeout = opts.detectTimeout;
+    this.detectMediaTimeout = opts.detectTimeout ?? this.detectMediaTimeout;
+    this.mediaTimeoutThreshold = opts.timeoutThreshold ?? this.mediaTimeoutThreshold;
 
-    if(opts.timeoutThreshold){
-      this.mediaTimeoutThreshold = opts.timeoutThreshold;
-    }
     this.iceServers = [{ urls: "stun:stun.l.google.com:19302" }];
     if (opts.iceServers) {
       this.iceServers = opts.iceServers;
@@ -138,16 +136,20 @@ export class WebRTCPlayer extends EventEmitter {
         }
       });
 
-      if (bytesReceivedBlock <= this.bytesReceived) {
-        this.timeoutThresholdCounter += this.msStatsInterval;
+      if(this.detectMediaTimeout == true) {
 
-        if (this.timeoutThresholdCounter >= this.mediaTimeoutThreshold) {
-          this.emit(Message.NO_MEDIA);
-          this.detectMediaTimeout = false;
+        if (bytesReceivedBlock <= this.bytesReceived) {
+          this.timeoutThresholdCounter += this.msStatsInterval;
+
+          if (this.timeoutThresholdCounter >= this.mediaTimeoutThreshold) {
+            this.emit(Message.NO_MEDIA);
+            console.log("no-media");
+          }
         }
-      }
-      else {
-        this.bytesReceived = bytesReceivedBlock;
+        else {
+          this.bytesReceived = bytesReceivedBlock;
+          this.timeoutThresholdCounter = 0;
+        }
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,9 +142,8 @@ export class WebRTCPlayer extends EventEmitter {
       if (bytesReceivedBlock <= this.bytesReceived) {
         this.timeoutThresholdCounter += this.msStatsInterval;
 
-        if (this.mediaTimeoutOccured == false && this.timeoutThresholdCounter >= this.mediaTimeoutThreshold) {
+        if (this.mediaTimeoutOccured === false && this.timeoutThresholdCounter >= this.mediaTimeoutThreshold) {
           this.emit(Message.NO_MEDIA);
-          console.log("no-media")
           this.mediaTimeoutOccured = true;
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,8 +201,8 @@ export class WebRTCPlayer extends EventEmitter {
 
   stop() {
     clearInterval(this.statsInterval);
-    this.peer.close();
-    this.videoElement.src = null;
+    this.peer.close(); 
+    this.videoElement.srcObject = undefined;
     this.videoElement.load();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,7 +143,6 @@ export class WebRTCPlayer extends EventEmitter {
 
           if (this.timeoutThresholdCounter >= this.mediaTimeoutThreshold) {
             this.emit(Message.NO_MEDIA);
-            console.log("no-media");
           }
         }
         else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "esnext",
     "sourceMap": true,
     "lib": ["ES2015", "dom"],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Basis for discussion on issue #29 'Player auto-reconnect on loss of WHIP Client video'

Also I realize my syntax formatting causes annoying changes. Perhaps we can sync on a standard.