### PR TITLE
feat: emit an event on initial connection failed (#45)

### DIFF
--- a/src/adapters/WHEPAdapter.ts
+++ b/src/adapters/WHEPAdapter.ts
@@ -206,6 +206,7 @@ export class WHEPAdapter implements Adapter {
         this.onErrorHandler('reconnectneeded');
       } else {
         this.error(`sendAnswer response: ${response.status}`);
+        this.onErrorHandler('connectionfailed');
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ export { ListAvailableAdapters } from './adapters/AdapterFactory';
 enum Message {
   NO_MEDIA = 'no-media',
   MEDIA_RECOVERED = 'media-recovered',
-  PEER_CONNECTION_FAILED = 'peer-connection-failed'
+  PEER_CONNECTION_FAILED = 'peer-connection-failed',
+  INITIAL_CONNECTION_FAILED = 'initial-connection-failed',
 }
 
 interface WebRTCPlayerOptions {
@@ -121,6 +122,11 @@ export class WebRTCPlayer extends EventEmitter {
         this.setupPeer();
         this.adapter.resetPeer(this.peer);
         this.adapter.connect();
+        break;
+      case 'connectionfailed':
+        this.peer && this.peer.close();
+        this.videoElement.srcObject = null;
+        this.emit(Message.INITIAL_CONNECTION_FAILED);
         break;
     }
   }


### PR DESCRIPTION
This addresses the issue raised in #45 by emitting an `initial-connection-failed` event if the WHEP request fails. It also properly cleans up the peer in this situation.

This allows you to do something like the following in your client code, giving good control over when to retry, and when to alert the user:

```
class SomeAngularComponent {
  connectionAttemptsRemaining = 3;

  private whepUrl?: string;

  async ngOnInit() {
    this.client = new WebRTCPlayer({
      video: this.video.nativeElement,
      type: 'whep',
    });

    this.client.on('initial-connection-failed', () => this.maybeRetryConnection());
    await this.client.load(new URL(this.whepUrl));
  }

  private maybeRetryConnection() {
    if (this.connectionAttemptsRemaining > 0) {
      this.client!.load(new URL(this.whepUrl!));
      this.connectionAttemptsRemaining--;
    } else {
      // Alert the user
    }
  }
}

```