### PR TITLE
fix: add callback for connecterror

### DIFF
--- a/src/adapters/WHEPAdapter.ts
+++ b/src/adapters/WHEPAdapter.ts
@@ -62,6 +62,7 @@ export class WHEPAdapter implements Adapter {
       await this.initSdpExchange();
     } catch (error) {
       console.error((error as Error).toString());
+      this.onErrorHandler('connecterror');
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,8 @@ enum Message {
   NO_MEDIA = 'no-media',
   MEDIA_RECOVERED = 'media-recovered',
   PEER_CONNECTION_FAILED = 'peer-connection-failed',
-  INITIAL_CONNECTION_FAILED = 'initial-connection-failed'
+  INITIAL_CONNECTION_FAILED = 'initial-connection-failed',
+  CONNECT_ERROR = 'connect-error'
 }
 
 export interface MediaConstraints {
@@ -145,6 +146,11 @@ export class WebRTCPlayer extends EventEmitter {
         this.peer && this.peer.close();
         this.videoElement.srcObject = null;
         this.emit(Message.INITIAL_CONNECTION_FAILED);
+        break;
+      case 'connecterror':
+        this.peer && this.peer.close();
+        this.adapter.resetPeer(this.peer);
+        this.emit(Message.CONNECT_ERROR);
         break;
     }
   }


### PR DESCRIPTION
I 'm using this library with cloudflare stream webrtc. I noticed an issue where if I attempt to play the whep url before the whip side has started, then the player will get an exception inside the whep adapter connect and stop. The sequence in this case was getting a retry, it trying to do the connect again, and then the error occurred.

This change adds a new message that can be received as an event, in my case I'm using it to retry the connection after 5 seconds. 