### PR TITLE
feat: add authorization header for whep, for stream key

### DIFF
--- a/src/adapters/AdapterFactory.ts
+++ b/src/adapters/AdapterFactory.ts
@@ -9,7 +9,8 @@ export interface AdapterFactoryFunction {
     peer: RTCPeerConnection,
     channelUrl: URL,
     onError: (error: string) => void,
-    mediaConstraints: MediaConstraints
+    mediaConstraints: MediaConstraints,
+    authKey: string | undefined
   ): Adapter;
 }
 
@@ -21,7 +22,8 @@ const WHPPAdapterFactory: AdapterFactoryFunction = (
   peer,
   channelUrl,
   onError,
-  mediaConstraints
+  mediaConstraints,
+  authKey
 ) => {
   return new WHPPAdapter(peer, channelUrl, onError);
 };
@@ -30,7 +32,8 @@ const EyevinnAdapterFactory: AdapterFactoryFunction = (
   peer,
   channelUrl,
   onError,
-  mediaConstraints
+  mediaConstraints,
+  authKey
 ) => {
   return new EyevinnAdapter(peer, channelUrl, onError);
 };
@@ -39,9 +42,10 @@ const WHEPAdapterFactory: AdapterFactoryFunction = (
   peer,
   channelUrl,
   onError,
-  mediaConstraints
+  mediaConstraints,
+  authKey
 ) => {
-  return new WHEPAdapter(peer, channelUrl, onError, mediaConstraints);
+  return new WHEPAdapter(peer, channelUrl, onError, mediaConstraints, authKey);
 };
 
 const adapters: AdapterMap = {
@@ -55,9 +59,10 @@ export function AdapterFactory(
   peer: RTCPeerConnection,
   channelUrl: URL,
   onError: (error: string) => void,
-  mediaConstraints: MediaConstraints
+  mediaConstraints: MediaConstraints,
+  authKey?: string
 ): Adapter {
-  return adapters[type](peer, channelUrl, onError, mediaConstraints);
+  return adapters[type](peer, channelUrl, onError, mediaConstraints, authKey);
 }
 
 export function ListAvailableAdapters(): string[] {

--- a/src/adapters/WHEPAdapter.ts
+++ b/src/adapters/WHEPAdapter.ts
@@ -11,6 +11,7 @@ export enum WHEPType {
 export class WHEPAdapter implements Adapter {
   private localPeer: RTCPeerConnection | undefined;
   private channelUrl: URL;
+  private authKey?: string;
   private debug = false;
   private whepType: WHEPType;
   private waitingForCandidates = false;
@@ -25,7 +26,8 @@ export class WHEPAdapter implements Adapter {
     peer: RTCPeerConnection,
     channelUrl: URL,
     onError: (error: string) => void,
-    mediaConstraints: MediaConstraints
+    mediaConstraints: MediaConstraints,
+    authKey: string | undefined
   ) {
     this.mediaConstraints = mediaConstraints;
     this.channelUrl = channelUrl;
@@ -35,6 +37,7 @@ export class WHEPAdapter implements Adapter {
       );
     }
     this.whepType = WHEPType.Client;
+    this.authKey = authKey;
 
     this.onErrorHandler = onError;
     this.audio = !this.mediaConstraints.videoOnly;
@@ -68,8 +71,11 @@ export class WHEPAdapter implements Adapter {
   async disconnect() {
     if (this.resource) {
       this.log(`Disconnecting by removing resource ${this.resource}`);
+      const headers: {Authorization?: string} = {};
+      this.authKey && (headers['Authorization'] = this.authKey);
       const response = await fetch(this.resource, {
-        method: 'DELETE'
+        method: 'DELETE',
+        headers,
       });
       if (response.ok) {
         this.log(`Successfully removed resource`);
@@ -191,11 +197,14 @@ export class WHEPAdapter implements Adapter {
   private async requestOffer() {
     if (this.whepType === WHEPType.Server) {
       this.log(`Requesting offer from: ${this.channelUrl}`);
+      const headers: {'Content-Type': string, Authorization?: string} = {
+        'Content-Type': 'application/sdp'
+      };
+      this.authKey && (headers['Authorization'] = this.authKey);
+
       const response = await fetch(this.channelUrl.toString(), {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/sdp'
-        },
+        headers,
         body: ''
       });
       if (response.ok) {
@@ -220,11 +229,13 @@ export class WHEPAdapter implements Adapter {
     if (this.whepType === WHEPType.Server && this.resource) {
       const answer = this.localPeer.localDescription;
       if (answer) {
+        const headers: {'Content-Type': string, Authorization?: string} = {
+          'Content-Type': 'application/sdp'
+        };
+        this.authKey && (headers['Authorization'] = this.authKey);
         const response = await fetch(this.resource, {
           method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/sdp'
-          },
+          headers,
           body: answer.sdp
         });
         if (!response.ok) {
@@ -244,11 +255,13 @@ export class WHEPAdapter implements Adapter {
 
     if (this.whepType === WHEPType.Client && offer) {
       this.log(`Sending offer to ${this.channelUrl}`);
+      const headers: {'Content-Type': string, Authorization?: string} = {
+        'Content-Type': 'application/sdp'
+      };
+      this.authKey && (headers['Authorization'] = this.authKey);
       const response = await fetch(this.channelUrl.toString(), {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/sdp'
-        },
+        headers,
         body: offer.sdp
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ export class WebRTCPlayer extends EventEmitter {
   private iceServers: RTCIceServer[];
   private debug: boolean;
   private channelUrl: URL = <URL>{};
+  private authKey?: string = undefined;
   private reconnectAttemptsLeft: number = RECONNECT_ATTEMPTS;
   private csaiManager?: CSAIManager;
   private adapter: Adapter = <Adapter>{};
@@ -93,8 +94,9 @@ export class WebRTCPlayer extends EventEmitter {
     }
   }
 
-  async load(channelUrl: URL) {
+  async load(channelUrl: URL, authKey: string | undefined = undefined) {
     this.channelUrl = channelUrl;
+    this.authKey = authKey;
     this.connect();
   }
 
@@ -229,14 +231,16 @@ export class WebRTCPlayer extends EventEmitter {
         this.peer,
         this.channelUrl,
         this.onErrorHandler.bind(this),
-        this.mediaConstraints
+        this.mediaConstraints,
+        this.authKey
       );
     } else if (this.adapterFactory) {
       this.adapter = this.adapterFactory(
         this.peer,
         this.channelUrl,
         this.onErrorHandler.bind(this),
-        this.mediaConstraints
+        this.mediaConstraints,
+        this.authKey
       );
     }
     if (!this.adapter) {


### PR DESCRIPTION
Servers like https://github.com/Glimesh/broadcast-box require an Authorization header to provide the stream key.

The whip client (https://github.com/Eyevinn/whip/blob/main/packages/sdk/src/WHIPProtocol.ts) supports providing an authkey and sends it to the header.

This PR does the same for the player for whep, to allow for the authorization header to be passed.