### PR TITLE
feat: allow custom RTCPeerConnection config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ interface WebRTCPlayerOptions {
   detectTimeout?: boolean;
   timeoutThreshold?: number;
   mediaConstraints?: MediaConstraints;
+  rtcConfiguration?: RTCConfiguration;
 }
 
 const RECONNECT_ATTEMPTS = 2;
@@ -64,6 +65,7 @@ export class WebRTCPlayer extends EventEmitter {
   private timeoutThresholdCounter = 0;
   private bytesReceived = 0;
   private mediaConstraints: MediaConstraints;
+  private rtcConfiguration?: RTCConfiguration;
 
   constructor(opts: WebRTCPlayerOptions) {
     super();
@@ -83,6 +85,7 @@ export class WebRTCPlayer extends EventEmitter {
       this.iceServers = opts.iceServers;
     }
     this.debug = !!opts.debug;
+    this.rtcConfiguration = opts.rtcConfiguration;
     if (opts.vmapUrl) {
       this.csaiManager = new CSAIManager({
         contentVideoElement: this.videoElement,
@@ -208,7 +211,7 @@ export class WebRTCPlayer extends EventEmitter {
   }
 
   private setupPeer() {
-    this.peer = new RTCPeerConnection({ iceServers: this.iceServers });
+    this.peer = new RTCPeerConnection({ iceServers: this.iceServers, ...this.rtcConfiguration });
     this.peer.onconnectionstatechange = this.onConnectionStateChange.bind(this);
     this.peer.ontrack = this.onTrack.bind(this);
   }


### PR DESCRIPTION
Allow custom RTCPeerConnection configuration. This is inspired of myown need to switch encodedInsertableStreams true to cater [WebRTC](https://github.com/w3c/webrtc-encoded-transform/blob/main/explainer.md) [Insertable Streams](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Using_Encoded_Transforms).

This edit hasn't thoroughly tested, so advices are welcomed. Alternatively, this workaround found successful in my test:
```ts
const OriginalRTCPeerConnection = window.RTCPeerConnection;
window.RTCPeerConnection = function (config: any) {
  // Force the flag into every new connection
  const newConfig = { ...config, encodedInsertableStreams: true };
  return new OriginalRTCPeerConnection(newConfig);
} as any;

const webrtcPlayer = new WebRTCPlayer({
  video: videoRef.current,
  type: 'whep',
});

window.RTCPeerConnection = OriginalRTCPeerConnection;
```