### PR TITLE
feat: configurable ICE gathering timeout

### DIFF
--- a/src/adapters/WHEPAdapter.ts
+++ b/src/adapters/WHEPAdapter.ts
@@ -71,7 +71,7 @@ export class WHEPAdapter implements Adapter {
 
   async connect(opts?: AdapterConnectOptions) {
     try {
-      await this.initSdpExchange();
+      await this.initSdpExchange(opts?.timeout ?? DEFAULT_CONNECT_TIMEOUT);
     } catch (error) {
       // If teardown happened while the SDP exchange was in flight, the peer is
       // already closed and the resulting error is expected — swallow it quietly
@@ -102,7 +102,7 @@ export class WHEPAdapter implements Adapter {
     }
   }
 
-  private async initSdpExchange() {
+  private async initSdpExchange(timeout: number = DEFAULT_CONNECT_TIMEOUT) {
     clearTimeout(this.iceGatheringTimeout);
 
     if (this.isClosed()) {
@@ -138,7 +138,7 @@ export class WHEPAdapter implements Adapter {
       this.waitingForCandidates = true;
       this.iceGatheringTimeout = setTimeout(
         this.onIceGatheringTimeout.bind(this),
-        DEFAULT_CONNECT_TIMEOUT
+        timeout
       );
     } else {
       if (this.localPeer) {
@@ -159,7 +159,7 @@ export class WHEPAdapter implements Adapter {
           this.waitingForCandidates = true;
           this.iceGatheringTimeout = setTimeout(
             this.onIceGatheringTimeout.bind(this),
-            DEFAULT_CONNECT_TIMEOUT
+            timeout
           );
         } catch (error) {
           this.log(answer.sdp);

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,12 +49,14 @@ interface WebRTCPlayerOptions {
   videoHealthPollIntervalMs?: number;
   videoFreezeThresholdMs?: number;
   reconnectOnOnline?: boolean;
+  iceGatheringTimeoutMs?: number;
 }
 
 const RECONNECT_ATTEMPTS = 5; // number of times to attempt reconnecting before giving up and emitting a reconnection failed event, can be configured with WebRTCPlayerOptions.reconnectAttemptsLeft
 const MEDIA_TIMEOUT_THRESHOLD = 15000; //15 seconds without media is considered a timeout, can be configured with WebRTCPlayerOptions.timeoutThreshold
 const VIDEO_HEALTH_POLL_INTERVAL = 1000; // how often to poll getStats() for video freeze detection, can be configured with WebRTCPlayerOptions.videoHealthPollIntervalMs
 const VIDEO_FREEZE_THRESHOLD = 3000; // how long the decoder can be stalled while packets keep arriving before we force a decoder recovery, can be configured with WebRTCPlayerOptions.videoFreezeThresholdMs
+const ICE_GATHERING_TIMEOUT = 2000; // how long to wait for ICE candidate gathering before sending the offer with whatever was gathered, can be configured with WebRTCPlayerOptions.iceGatheringTimeoutMs
 
 export class WebRTCPlayer extends EventEmitter {
   private videoElement: HTMLVideoElement;
@@ -87,6 +89,7 @@ export class WebRTCPlayer extends EventEmitter {
   private videoFreezeElapsedMs = 0;
   private reconnectOnOnline: boolean;
   private onlineListener: (() => void) | undefined;
+  private iceGatheringTimeoutMs = ICE_GATHERING_TIMEOUT;
 
   constructor(opts: WebRTCPlayerOptions) {
     super();
@@ -122,6 +125,8 @@ export class WebRTCPlayer extends EventEmitter {
       this.onlineListener = this.onNetworkOnline.bind(this);
       window.addEventListener('online', this.onlineListener);
     }
+    this.iceGatheringTimeoutMs =
+      opts.iceGatheringTimeoutMs ?? ICE_GATHERING_TIMEOUT;
     if (opts.vmapUrl) {
       this.csaiManager = new CSAIManager({
         contentVideoElement: this.videoElement,
@@ -216,7 +221,7 @@ export class WebRTCPlayer extends EventEmitter {
         this.videoElement.srcObject = null;
         this.setupPeer();
         this.adapter.resetPeer(this.peer);
-        this.adapter.connect();
+        this.adapter.connect({ timeout: this.iceGatheringTimeoutMs });
         break;
       case 'connectionfailed':
         this.peer && this.peer.close();
@@ -433,7 +438,7 @@ export class WebRTCPlayer extends EventEmitter {
       this.msStatsInterval
     );
     try {
-      await this.adapter.connect();
+      await this.adapter.connect({ timeout: this.iceGatheringTimeoutMs });
     } catch (error) {
       console.error(error);
       this.stop();


### PR DESCRIPTION
## Summary
- Implements #93: make the ICE-gathering wait before the SDP offer is sent configurable instead of a fixed 2000 ms.

## Changes
- New optional `WebRTCPlayerOptions.iceGatheringTimeoutMs` (default 2000 ms). Stored on the player and passed to the adapter via the existing `AdapterConnectOptions.timeout` field on both the initial `connect()` and the `reconnectneeded` re-connect path.
- The WHEP adapter (`WHEPAdapter`) previously ignored its `connect(opts)` argument and always used a hardcoded 2000 ms. It now threads `opts.timeout` into `initSdpExchange()` and uses it for the `onIceGatheringTimeout` fallback timer in both the client-offer and server-offer flows. When the timer fires the existing `onDoneWaitingForCandidates()` path sends whatever candidates were gathered — matching the existing ICE-gather-then-offer flow, just with a configurable deadline.
- Also fixed a pre-existing Prettier formatting error in `setupPeer()`.

### Public API surface
- Adds one optional config field. `WHEPAdapter.connect()` now honors its already-declared `opts.timeout` argument (previously a no-op) — behavior-only, signature unchanged. Not a breaking change; the default preserves the prior 2000 ms.

## Test plan
Repo has NO unit-test suite. PROOF:
- `npm run lint` -> `21 problems (0 errors, 21 warnings)` (warnings pre-existing; one fewer than before because the previously-unused `opts` param is now used)
- `npm run pretty` -> `All matched files use Prettier code style!`
- `npm run typecheck` -> clean
- `npm run build:demo` -> built OK

Note: `npm run build` (main+types) fails on a pre-existing `@parcel/transformer-typescript-types` 2.8.3 vs `parcel` 2.16.4 lockfile mismatch, reproducible on unmodified `main`.

Closes #93

🤖 Automated via WebRTC daily-backlog-pr skill