### PR TITLE
feat: built-in WebRTC stats collection

### DIFF
--- a/src/StatsCollector.ts
+++ b/src/StatsCollector.ts
@@ -1,0 +1,282 @@
+// Built-in periodic WebRTC playback stats.
+//
+// Collects RTCStatsReport samples on an interval and derives per-second
+// playback quality metrics (bitrate, fps, packet loss, jitter buffer, A/V
+// sync, ICE candidate type, ...) from the cumulative counters exposed by
+// getStats(). Opt-in: nothing runs until start() is called.
+
+const EMA_ALPHA = 0.3; // smoothing factor for the jitter-buffer delay estimate
+
+export type IceCandidateType = 'host' | 'srflx' | 'prflx' | 'relay' | 'unknown';
+
+export interface MediaTrackStats {
+  bitrate: number; // bits per second, derived from the byte-count delta
+  packetsLost: number; // cumulative packets lost
+  packetLoss: number; // fraction lost over the interval (0..1)
+  jitter: number; // milliseconds
+  jitterBufferDelay: number; // EMA-smoothed per-frame/sample delay, milliseconds
+}
+
+export interface VideoTrackStats extends MediaTrackStats {
+  framesPerSecond: number;
+  framesDecoded: number; // cumulative
+  frameWidth?: number;
+  frameHeight?: number;
+  nackCount: number; // cumulative
+  pliCount: number; // cumulative
+  firCount: number; // cumulative
+}
+
+export interface WebRTCStats {
+  timestamp: number;
+  video?: VideoTrackStats;
+  audio?: MediaTrackStats;
+  avSyncOffsetMs?: number; // audio jbuf delay - video jbuf delay
+  iceCandidateType?: IceCandidateType;
+}
+
+// Cumulative counters retained between samples so we can compute deltas.
+interface Sample {
+  timestamp: number;
+  bytesReceived: number;
+  packetsReceived: number;
+  packetsLost: number;
+  framesDecoded: number;
+  jitterBufferDelay: number; // cumulative seconds
+  jitterBufferEmittedCount: number; // cumulative frames/samples
+}
+
+const emptySample = (): Sample => ({
+  timestamp: 0,
+  bytesReceived: 0,
+  packetsReceived: 0,
+  packetsLost: 0,
+  framesDecoded: 0,
+  jitterBufferDelay: 0,
+  jitterBufferEmittedCount: 0
+});
+
+export class StatsCollector {
+  private getStats: () => Promise<RTCStatsReport>;
+  private intervalMs: number;
+  private interval: ReturnType<typeof setInterval> | undefined;
+  private onStats: (stats: WebRTCStats) => void;
+
+  private prevVideo: Sample = emptySample();
+  private prevAudio: Sample = emptySample();
+  private videoJbufEma: number | undefined;
+  private audioJbufEma: number | undefined;
+
+  constructor(
+    getStats: () => Promise<RTCStatsReport>,
+    intervalMs: number,
+    onStats: (stats: WebRTCStats) => void
+  ) {
+    this.getStats = getStats;
+    this.intervalMs = intervalMs;
+    this.onStats = onStats;
+  }
+
+  start() {
+    if (this.interval) {
+      return;
+    }
+    this.interval = setInterval(this.sample.bind(this), this.intervalMs);
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = undefined;
+    }
+    this.prevVideo = emptySample();
+    this.prevAudio = emptySample();
+    this.videoJbufEma = undefined;
+    this.audioJbufEma = undefined;
+  }
+
+  private async sample() {
+    let report: RTCStatsReport;
+    try {
+      report = await this.getStats();
+    } catch {
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const byId = new Map<string, any>();
+    report.forEach((r) => byId.set(r.id, r));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let videoInbound: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let audioInbound: any;
+    let iceCandidateType: IceCandidateType | undefined;
+
+    report.forEach((r) => {
+      if (r.type === 'inbound-rtp') {
+        if (r.kind === 'video') {
+          videoInbound = r;
+        } else if (r.kind === 'audio') {
+          audioInbound = r;
+        }
+      } else if (
+        r.type === 'candidate-pair' &&
+        (r.nominated || r.state === 'succeeded') &&
+        r.selected !== false
+      ) {
+        const local = r.localCandidateId
+          ? byId.get(r.localCandidateId)
+          : undefined;
+        if (local && typeof local.candidateType === 'string') {
+          iceCandidateType = this.normalizeCandidateType(local.candidateType);
+        }
+      }
+    });
+
+    const stats: WebRTCStats = {
+      timestamp: Date.now(),
+      iceCandidateType
+    };
+
+    if (videoInbound) {
+      const { sample, metrics } = this.deriveVideo(videoInbound);
+      this.prevVideo = sample;
+      stats.video = metrics;
+    }
+
+    if (audioInbound) {
+      const { sample, metrics } = this.deriveAudio(audioInbound);
+      this.prevAudio = sample;
+      stats.audio = metrics;
+    }
+
+    if (stats.video && stats.audio) {
+      stats.avSyncOffsetMs =
+        stats.audio.jitterBufferDelay - stats.video.jitterBufferDelay;
+    }
+
+    this.onStats(stats);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private deriveVideo(r: any): { sample: Sample; metrics: VideoTrackStats } {
+    const sample: Sample = {
+      timestamp: r.timestamp ?? Date.now(),
+      bytesReceived: r.bytesReceived ?? 0,
+      packetsReceived: r.packetsReceived ?? 0,
+      packetsLost: r.packetsLost ?? 0,
+      framesDecoded: r.framesDecoded ?? 0,
+      jitterBufferDelay: r.jitterBufferDelay ?? 0,
+      jitterBufferEmittedCount: r.jitterBufferEmittedCount ?? 0
+    };
+    const prev = this.prevVideo;
+    const seconds = this.deltaSeconds(prev.timestamp, sample.timestamp);
+
+    const framesPerSecond =
+      seconds > 0
+        ? Math.max(0, (sample.framesDecoded - prev.framesDecoded) / seconds)
+        : 0;
+
+    this.videoJbufEma = this.updateJbufEma(this.videoJbufEma, prev, sample);
+
+    const metrics: VideoTrackStats = {
+      bitrate: this.bitrate(prev, sample, seconds),
+      packetsLost: sample.packetsLost,
+      packetLoss: this.packetLoss(prev, sample),
+      jitter: (r.jitter ?? 0) * 1000,
+      jitterBufferDelay: this.videoJbufEma ?? 0,
+      framesPerSecond,
+      framesDecoded: sample.framesDecoded,
+      frameWidth: r.frameWidth,
+      frameHeight: r.frameHeight,
+      nackCount: r.nackCount ?? 0,
+      pliCount: r.pliCount ?? 0,
+      firCount: r.firCount ?? 0
+    };
+    return { sample, metrics };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private deriveAudio(r: any): { sample: Sample; metrics: MediaTrackStats } {
+    const sample: Sample = {
+      timestamp: r.timestamp ?? Date.now(),
+      bytesReceived: r.bytesReceived ?? 0,
+      packetsReceived: r.packetsReceived ?? 0,
+      packetsLost: r.packetsLost ?? 0,
+      framesDecoded: 0,
+      jitterBufferDelay: r.jitterBufferDelay ?? 0,
+      jitterBufferEmittedCount: r.jitterBufferEmittedCount ?? 0
+    };
+    const prev = this.prevAudio;
+    const seconds = this.deltaSeconds(prev.timestamp, sample.timestamp);
+
+    this.audioJbufEma = this.updateJbufEma(this.audioJbufEma, prev, sample);
+
+    const metrics: MediaTrackStats = {
+      bitrate: this.bitrate(prev, sample, seconds),
+      packetsLost: sample.packetsLost,
+      packetLoss: this.packetLoss(prev, sample),
+      jitter: (r.jitter ?? 0) * 1000,
+      jitterBufferDelay: this.audioJbufEma ?? 0
+    };
+    return { sample, metrics };
+  }
+
+  private deltaSeconds(prevTs: number, ts: number): number {
+    if (!prevTs) {
+      return 0;
+    }
+    return (ts - prevTs) / 1000;
+  }
+
+  private bitrate(prev: Sample, sample: Sample, seconds: number): number {
+    if (seconds <= 0) {
+      return 0;
+    }
+    const deltaBytes = sample.bytesReceived - prev.bytesReceived;
+    return Math.max(0, (deltaBytes * 8) / seconds);
+  }
+
+  private packetLoss(prev: Sample, sample: Sample): number {
+    const deltaLost = sample.packetsLost - prev.packetsLost;
+    const deltaReceived = sample.packetsReceived - prev.packetsReceived;
+    const deltaExpected = deltaReceived + deltaLost;
+    if (deltaExpected <= 0) {
+      return 0;
+    }
+    return Math.max(0, Math.min(1, deltaLost / deltaExpected));
+  }
+
+  // Per-frame/sample jitter buffer delay from the cumulative counters,
+  // smoothed with an exponential moving average (alpha = 0.3).
+  private updateJbufEma(
+    ema: number | undefined,
+    prev: Sample,
+    sample: Sample
+  ): number | undefined {
+    const deltaDelay = sample.jitterBufferDelay - prev.jitterBufferDelay;
+    const deltaCount =
+      sample.jitterBufferEmittedCount - prev.jitterBufferEmittedCount;
+    if (deltaCount <= 0) {
+      return ema;
+    }
+    const instantaneousMs = (deltaDelay / deltaCount) * 1000;
+    if (ema === undefined) {
+      return instantaneousMs;
+    }
+    return EMA_ALPHA * instantaneousMs + (1 - EMA_ALPHA) * ema;
+  }
+
+  private normalizeCandidateType(type: string): IceCandidateType {
+    switch (type) {
+      case 'host':
+      case 'srflx':
+      case 'prflx':
+      case 'relay':
+        return type;
+      default:
+        return 'unknown';
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,15 @@ import {
 } from './adapters/AdapterFactory';
 import { EventEmitter } from 'events';
 import { CSAIManager } from '@eyevinn/csai-manager';
+import { StatsCollector, WebRTCStats } from './StatsCollector';
 
 export { ListAvailableAdapters } from './adapters/AdapterFactory';
+export type {
+  WebRTCStats,
+  VideoTrackStats,
+  MediaTrackStats,
+  IceCandidateType
+} from './StatsCollector';
 
 enum Message {
   NO_MEDIA = 'no-media',
@@ -19,7 +26,8 @@ enum Message {
   PLAYER_MUTED = 'player-muted',
   PLAYER_UNMUTED = 'player-unmuted',
   VIDEO_RECOVERY_ATTEMPT = 'video-recovery-attempt',
-  NETWORK_ONLINE_RECONNECT = 'network-online-reconnect'
+  NETWORK_ONLINE_RECONNECT = 'network-online-reconnect',
+  STATS = 'stats'
 }
 
 export interface MediaConstraints {
@@ -50,6 +58,8 @@ interface WebRTCPlayerOptions {
   videoFreezeThresholdMs?: number;
   reconnectOnOnline?: boolean;
   iceGatheringTimeoutMs?: number;
+  statsCollection?: boolean;
+  statsCollectionIntervalMs?: number;
 }
 
 const RECONNECT_ATTEMPTS = 5; // number of times to attempt reconnecting before giving up and emitting a reconnection failed event, can be configured with WebRTCPlayerOptions.reconnectAttemptsLeft
@@ -57,6 +67,7 @@ const MEDIA_TIMEOUT_THRESHOLD = 15000; //15 seconds without media is considered 
 const VIDEO_HEALTH_POLL_INTERVAL = 1000; // how often to poll getStats() for video freeze detection, can be configured with WebRTCPlayerOptions.videoHealthPollIntervalMs
 const VIDEO_FREEZE_THRESHOLD = 3000; // how long the decoder can be stalled while packets keep arriving before we force a decoder recovery, can be configured with WebRTCPlayerOptions.videoFreezeThresholdMs
 const ICE_GATHERING_TIMEOUT = 2000; // how long to wait for ICE candidate gathering before sending the offer with whatever was gathered, can be configured with WebRTCPlayerOptions.iceGatheringTimeoutMs
+const STATS_COLLECTION_INTERVAL = 1000; // how often to sample getStats() for the derived per-second 'stats' event, can be configured with WebRTCPlayerOptions.statsCollectionIntervalMs
 
 export class WebRTCPlayer extends EventEmitter {
   private videoElement: HTMLVideoElement;
@@ -90,6 +101,9 @@ export class WebRTCPlayer extends EventEmitter {
   private reconnectOnOnline: boolean;
   private onlineListener: (() => void) | undefined;
   private iceGatheringTimeoutMs = ICE_GATHERING_TIMEOUT;
+  private statsCollectionEnabled: boolean;
+  private statsCollectionIntervalMs = STATS_COLLECTION_INTERVAL;
+  private statsCollector?: StatsCollector;
 
   constructor(opts: WebRTCPlayerOptions) {
     super();
@@ -127,6 +141,9 @@ export class WebRTCPlayer extends EventEmitter {
     }
     this.iceGatheringTimeoutMs =
       opts.iceGatheringTimeoutMs ?? ICE_GATHERING_TIMEOUT;
+    this.statsCollectionEnabled = opts.statsCollection ?? false;
+    this.statsCollectionIntervalMs =
+      opts.statsCollectionIntervalMs ?? STATS_COLLECTION_INTERVAL;
     if (opts.vmapUrl) {
       this.csaiManager = new CSAIManager({
         contentVideoElement: this.videoElement,
@@ -272,6 +289,25 @@ export class WebRTCPlayer extends EventEmitter {
           this.mediaTimeoutOccured = false;
         }
       }
+    }
+  }
+
+  private startStatsCollection() {
+    // A fresh collector per peer connection so cumulative-counter deltas never
+    // span two different sessions.
+    this.stopStatsCollection();
+    this.statsCollector = new StatsCollector(
+      () => this.peer.getStats(null),
+      this.statsCollectionIntervalMs,
+      (stats: WebRTCStats) => this.emit(Message.STATS, stats)
+    );
+    this.statsCollector.start();
+  }
+
+  private stopStatsCollection() {
+    if (this.statsCollector) {
+      this.statsCollector.stop();
+      this.statsCollector = undefined;
     }
   }
 
@@ -437,6 +473,11 @@ export class WebRTCPlayer extends EventEmitter {
       this.onConnectionStats.bind(this),
       this.msStatsInterval
     );
+
+    if (this.statsCollectionEnabled) {
+      this.startStatsCollection();
+    }
+
     try {
       await this.adapter.connect({ timeout: this.iceGatheringTimeoutMs });
     } catch (error) {
@@ -461,6 +502,7 @@ export class WebRTCPlayer extends EventEmitter {
   stop() {
     clearInterval(this.statsInterval);
     this.stopVideoHealthMonitor();
+    this.stopStatsCollection();
     // Closing the peer connection flips its signalingState to 'closed', which
     // the adapter observes to short-circuit any in-flight SDP exchange started
     // before the connection was established (see WHEPAdapter). Guard against a


### PR DESCRIPTION
## Summary
- Implements #94: an opt-in periodic `stats` event with structured, per-second playback quality metrics derived from `getStats()`.

## Changes
- New module `src/StatsCollector.ts` exporting typed interfaces `WebRTCStats`, `VideoTrackStats`, `MediaTrackStats`, `IceCandidateType` and a `StatsCollector` class. It samples `RTCStatsReport` on an interval and derives:
  - video/audio bitrate (delta bytes x 8 / delta seconds)
  - FPS (delta `framesDecoded`)
  - jitter (ms), packet loss (delta lost / delta expected)
  - jitter buffer delay per-frame/sample, EMA-smoothed (alpha=0.3) from the cumulative `jitterBufferDelay` / `jitterBufferEmittedCount` counters
  - cumulative NACK / PLI / FIR counts, resolution (`frameWidth`/`frameHeight`)
  - A/V sync offset (audio jbuf delay minus video jbuf delay)
  - selected ICE candidate type (host/srflx/prflx/relay) from the nominated candidate-pair's local candidate
- New opt-in `WebRTCPlayerOptions.statsCollection` (default `false`) and `statsCollectionIntervalMs` (default 1000). When enabled the player creates a fresh collector per peer connection (so counter deltas never span sessions) and emits a typed `stats` (`WebRTCStats`) event each interval. Collector is torn down in `stop()`/`destroy()`.
- Zero overhead when unused (nothing runs unless `statsCollection` is set). Works alongside the existing `statsTypeFilter` `stats:<type>` passthrough, which is untouched.

### Public API surface
- Adds two optional config fields, a new emitted `stats` event, and four new exported types from the package entry point. No existing export signature changed. New exports only — not a breaking change.

## Test plan
Repo has NO unit-test suite. PROOF:
- `npm run lint` -> `22 problems (0 errors, 22 warnings)` (all warnings pre-existing in adapters; the new module is clean)
- `npm run pretty` -> `All matched files use Prettier code style!`
- `npm run typecheck` -> clean
- `npm run build:demo` -> built OK (new module bundles; demo js grew ~4 kB)

Manual reasoning: metrics are computed purely from documented `RTCInboundRtpStreamStats` / `RTCIceCandidatePairStats` / `RTCIceCandidateStats` fields per the getStats spec; all deltas are floored at 0 and packet-loss clamped to [0,1] to stay robust across browser counter quirks.

Note: `npm run build` (main+types) fails on a pre-existing `@parcel/transformer-typescript-types` 2.8.3 vs `parcel` 2.16.4 lockfile mismatch, reproducible on unmodified `main`.

Closes #94

🤖 Automated via WebRTC daily-backlog-pr skill