### PR TITLE
feat: add authToken option for Bearer auth on WHEP SDP POST/DELETE

### DIFF
--- a/src/adapters/AdapterFactory.ts
+++ b/src/adapters/AdapterFactory.ts
@@ -1,7 +1,7 @@
 import { Adapter } from './Adapter';
 import { WHPPAdapter } from './WHPPAdapter';
 import { EyevinnAdapter } from './EyevinnAdapter';
-import { WHEPAdapter } from './WHEPAdapter';
+import { WHEPAdapter, WHEPAdapterOptions } from './WHEPAdapter';
 import { MediaConstraints } from '../index';
 
 export interface AdapterFactoryFunction {
@@ -10,7 +10,8 @@ export interface AdapterFactoryFunction {
     channelUrl: URL,
     onError: (error: string) => void,
     mediaConstraints: MediaConstraints,
-    authKey: string | undefined
+    authKey: string | undefined,
+    options?: WHEPAdapterOptions
   ): Adapter;
 }
 
@@ -43,9 +44,17 @@ const WHEPAdapterFactory: AdapterFactoryFunction = (
   channelUrl,
   onError,
   mediaConstraints,
-  authKey
+  authKey,
+  options
 ) => {
-  return new WHEPAdapter(peer, channelUrl, onError, mediaConstraints, authKey);
+  return new WHEPAdapter(
+    peer,
+    channelUrl,
+    onError,
+    mediaConstraints,
+    authKey,
+    options
+  );
 };
 
 const adapters: AdapterMap = {
@@ -60,9 +69,17 @@ export function AdapterFactory(
   channelUrl: URL,
   onError: (error: string) => void,
   mediaConstraints: MediaConstraints,
-  authKey?: string
+  authKey?: string,
+  options?: WHEPAdapterOptions
 ): Adapter {
-  return adapters[type](peer, channelUrl, onError, mediaConstraints, authKey);
+  return adapters[type](
+    peer,
+    channelUrl,
+    onError,
+    mediaConstraints,
+    authKey,
+    options
+  );
 }
 
 export function ListAvailableAdapters(): string[] {

--- a/src/adapters/WHEPAdapter.ts
+++ b/src/adapters/WHEPAdapter.ts
@@ -8,10 +8,18 @@ export enum WHEPType {
   Server
 }
 
+export interface WHEPAdapterOptions {
+  // Bearer token injected as `Authorization: Bearer <token>` on the SDP
+  // POST (offer) and DELETE (teardown) signaling requests. The token is
+  // never logged.
+  authToken?: string;
+}
+
 export class WHEPAdapter implements Adapter {
   private localPeer: RTCPeerConnection | undefined;
   private channelUrl: URL;
   private authKey?: string;
+  private authToken?: string;
   private debug = false;
   private whepType: WHEPType;
   private waitingForCandidates = false;
@@ -28,7 +36,8 @@ export class WHEPAdapter implements Adapter {
     channelUrl: URL,
     onError: (error: string) => void,
     mediaConstraints: MediaConstraints,
-    authKey: string | undefined
+    authKey: string | undefined,
+    options?: WHEPAdapterOptions
   ) {
     this.mediaConstraints = mediaConstraints;
     this.channelUrl = channelUrl;
@@ -39,6 +48,7 @@ export class WHEPAdapter implements Adapter {
     }
     this.whepType = WHEPType.Client;
     this.authKey = authKey;
+    this.authToken = options?.authToken;
 
     this.onErrorHandler = onError;
     this.audio = !this.mediaConstraints.videoOnly;
@@ -84,6 +94,17 @@ export class WHEPAdapter implements Adapter {
     }
   }
 
+  // Builds the Authorization header value for signaling requests. A configured
+  // `authToken` is sent as a Bearer credential; otherwise the raw `authKey`
+  // header value is used if present. The returned value is applied to request
+  // headers only and is never passed to any logging path.
+  private getAuthorizationHeader(): string | undefined {
+    if (this.authToken) {
+      return `Bearer ${this.authToken}`;
+    }
+    return this.authKey;
+  }
+
   async disconnect() {
     this.closed = true;
     this.waitingForCandidates = false;
@@ -91,7 +112,8 @@ export class WHEPAdapter implements Adapter {
     if (this.resource) {
       this.log(`Disconnecting by removing resource ${this.resource}`);
       const headers: { Authorization?: string } = {};
-      this.authKey && (headers['Authorization'] = this.authKey);
+      const authorization = this.getAuthorizationHeader();
+      authorization && (headers['Authorization'] = authorization);
       const response = await fetch(this.resource, {
         method: 'DELETE',
         headers
@@ -259,7 +281,8 @@ export class WHEPAdapter implements Adapter {
       const headers: { 'Content-Type': string; Authorization?: string } = {
         'Content-Type': 'application/sdp'
       };
-      this.authKey && (headers['Authorization'] = this.authKey);
+      const authorization = this.getAuthorizationHeader();
+      authorization && (headers['Authorization'] = authorization);
 
       const response = await fetch(this.channelUrl.toString(), {
         method: 'POST',
@@ -295,7 +318,8 @@ export class WHEPAdapter implements Adapter {
         const headers: { 'Content-Type': string; Authorization?: string } = {
           'Content-Type': 'application/sdp'
         };
-        this.authKey && (headers['Authorization'] = this.authKey);
+        const authorization = this.getAuthorizationHeader();
+        authorization && (headers['Authorization'] = authorization);
         const response = await fetch(this.resource, {
           method: 'PATCH',
           headers,
@@ -325,7 +349,8 @@ export class WHEPAdapter implements Adapter {
       const headers: { 'Content-Type': string; Authorization?: string } = {
         'Content-Type': 'application/sdp'
       };
-      this.authKey && (headers['Authorization'] = this.authKey);
+      const authorization = this.getAuthorizationHeader();
+      authorization && (headers['Authorization'] = authorization);
       const response = await fetch(this.channelUrl.toString(), {
         method: 'POST',
         headers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,10 @@ interface WebRTCPlayerOptions {
   statsCollectionIntervalMs?: number;
   numAudioTracks?: number;
   numVideoTracks?: number;
+  // Bearer token injected as `Authorization: Bearer <token>` on the WHEP SDP
+  // POST (offer) and DELETE (teardown) signaling requests. The token is never
+  // logged. Usable independently of the `authKey` passed to `load()`.
+  authToken?: string;
 }
 
 const RECONNECT_ATTEMPTS = 5; // number of times to attempt reconnecting before giving up and emitting a reconnection failed event, can be configured with WebRTCPlayerOptions.reconnectAttemptsLeft
@@ -118,6 +122,7 @@ export class WebRTCPlayer extends EventEmitter {
   private statsCollectionIntervalMs = STATS_COLLECTION_INTERVAL;
   private statsCollector?: StatsCollector;
   private availableTracks: AvailableTrack[] = [];
+  private authToken?: string = undefined;
 
   constructor(opts: WebRTCPlayerOptions) {
     super();
@@ -164,6 +169,7 @@ export class WebRTCPlayer extends EventEmitter {
     this.statsCollectionEnabled = opts.statsCollection ?? false;
     this.statsCollectionIntervalMs =
       opts.statsCollectionIntervalMs ?? STATS_COLLECTION_INTERVAL;
+    this.authToken = opts.authToken;
     if (opts.vmapUrl) {
       this.csaiManager = new CSAIManager({
         contentVideoElement: this.videoElement,
@@ -551,7 +557,8 @@ export class WebRTCPlayer extends EventEmitter {
         this.channelUrl,
         this.onErrorHandler.bind(this),
         this.mediaConstraints,
-        this.authKey
+        this.authKey,
+        { authToken: this.authToken }
       );
     } else if (this.adapterFactory) {
       this.adapter = this.adapterFactory(
@@ -559,7 +566,8 @@ export class WebRTCPlayer extends EventEmitter {
         this.channelUrl,
         this.onErrorHandler.bind(this),
         this.mediaConstraints,
-        this.authKey
+        this.authKey,
+        { authToken: this.authToken }
       );
     }
     if (!this.adapter) {


### PR DESCRIPTION
## Summary
- Implements #104: add an `authToken` config option that injects an `Authorization: Bearer <token>` header on the WHEP SDP POST (offer) and DELETE (teardown) signaling requests.

## Changes
- `src/adapters/WHEPAdapter.ts`: new exported `WHEPAdapterOptions` interface with optional `authToken`; new `getAuthorizationHeader()` helper that returns `Bearer <token>` when `authToken` is set, else falls back to the existing raw `authKey` header value. Applied to the POST offer path (`sendOffer` and `requestOffer`), the DELETE teardown path (`disconnect`), and the PATCH answer path for consistency.
- `src/adapters/AdapterFactory.ts`: `AdapterFactoryFunction`, `AdapterFactory()` and the WHEP factory take an additional optional trailing `options?: WHEPAdapterOptions` argument (additive, defaulted — existing callers unaffected).
- `src/index.ts`: new optional `authToken` on `WebRTCPlayerOptions`, stored and forwarded to the adapter. Usable independently of the `authKey` passed to `load()`.

Public-API note: the new `authToken` option and `WHEPAdapterOptions` are purely additive. The extra optional trailing param on `AdapterFactoryFunction`/`AdapterFactory` is additive (optional, defaulted); custom adapter factories with the previous arity remain compatible. Not a breaking change.

Token-leak safety: the token is only ever assigned to a request `headers` object passed to `fetch`. No `log()`/`error()`/`console.*` call in the changed paths receives the header value, the `authorization` local, `authToken`, or `authKey`. Verified by auditing every logging statement in `WHEPAdapter.ts`.

## Test plan
- `npx prettier --check` on changed files: `All matched files use Prettier code style!`
- `npm run typecheck`: passes (no output/errors)
- `npm run build:demo`: `✨ Built in 1.95s` (bundles real source)
- Caveats (pre-existing, unrelated to this change): full `npm run build` is broken on `main` by a pre-existing `@parcel/*` lockfile drift (being fixed in PR #98). Additionally `npm run pretty`/`npm run lint` report one pre-existing prettier violation on the `setupPeer` line of `src/index.ts` that is present on `main` (verified via stash) and untouched here; not fixed to avoid unrelated reformatting. Repo has no unit-test suite (`npm test` is a stub).

Closes #104

🤖 Automated via WebRTC daily-backlog-pr skill