### PR TITLE
fix: guard signaling operations after destroy to avoid InvalidStateError

### DIFF
--- a/src/adapters/WHEPAdapter.ts
+++ b/src/adapters/WHEPAdapter.ts
@@ -21,6 +21,7 @@ export class WHEPAdapter implements Adapter {
   private audio: boolean;
   private video: boolean;
   private mediaConstraints: MediaConstraints;
+  private closed = false;
 
   constructor(
     peer: RTCPeerConnection,
@@ -60,16 +61,33 @@ export class WHEPAdapter implements Adapter {
     return this.localPeer;
   }
 
+  // True once teardown has begun, or once the underlying peer connection has
+  // been closed (e.g. by `destroy()` on the player before the connection was
+  // established). Used to short-circuit any in-flight signaling steps so that
+  // operations on a closed peer do not throw `InvalidStateError`.
+  private isClosed(): boolean {
+    return this.closed || this.localPeer?.signalingState === 'closed';
+  }
+
   async connect(opts?: AdapterConnectOptions) {
     try {
       await this.initSdpExchange();
     } catch (error) {
+      // If teardown happened while the SDP exchange was in flight, the peer is
+      // already closed and the resulting error is expected — swallow it quietly
+      // instead of reporting a connect error.
+      if (this.isClosed()) {
+        return;
+      }
       console.error((error as Error).toString());
       this.onErrorHandler('connecterror');
     }
   }
 
   async disconnect() {
+    this.closed = true;
+    this.waitingForCandidates = false;
+    clearTimeout(this.iceGatheringTimeout);
     if (this.resource) {
       this.log(`Disconnecting by removing resource ${this.resource}`);
       const headers: { Authorization?: string } = {};
@@ -87,12 +105,22 @@ export class WHEPAdapter implements Adapter {
   private async initSdpExchange() {
     clearTimeout(this.iceGatheringTimeout);
 
+    if (this.isClosed()) {
+      return;
+    }
+
     if (this.localPeer && this.whepType === WHEPType.Client) {
       if (this.video)
         this.localPeer.addTransceiver('video', { direction: 'recvonly' });
       if (this.audio)
         this.localPeer.addTransceiver('audio', { direction: 'recvonly' });
       const offer = await this.localPeer.createOffer();
+
+      // Teardown may have happened while awaiting the offer; bail out before
+      // touching the (now closed) peer to avoid an InvalidStateError.
+      if (this.isClosed()) {
+        return;
+      }
 
       // To add NACK in offer we have to add it manually see https://bugs.chromium.org/p/webrtc/issues/detail?id=4543 for details
       if (offer.sdp) {
@@ -115,11 +143,17 @@ export class WHEPAdapter implements Adapter {
     } else {
       if (this.localPeer) {
         const offer = await this.requestOffer();
+        if (this.isClosed()) {
+          return;
+        }
         await this.localPeer.setRemoteDescription({
           type: 'offer',
           sdp: offer
         });
         const answer = await this.localPeer.createAnswer();
+        if (this.isClosed()) {
+          return;
+        }
         try {
           await this.localPeer.setLocalDescription(answer);
           this.waitingForCandidates = true;
@@ -149,6 +183,9 @@ export class WHEPAdapter implements Adapter {
   }
 
   private onIceGatheringStateChange(event: Event) {
+    if (this.isClosed()) {
+      return;
+    }
     if (this.localPeer) {
       this.log('IceGatheringState', this.localPeer.iceGatheringState);
       if (
@@ -165,7 +202,7 @@ export class WHEPAdapter implements Adapter {
   private onIceGatheringTimeout() {
     this.log('IceGatheringTimeout');
 
-    if (!this.waitingForCandidates) {
+    if (this.isClosed() || !this.waitingForCandidates) {
       return;
     }
 
@@ -175,6 +212,10 @@ export class WHEPAdapter implements Adapter {
   private async onDoneWaitingForCandidates() {
     this.waitingForCandidates = false;
     clearTimeout(this.iceGatheringTimeout);
+
+    if (this.isClosed()) {
+      return;
+    }
 
     if (this.whepType === WHEPType.Client) {
       await this.sendOffer();
@@ -227,6 +268,10 @@ export class WHEPAdapter implements Adapter {
       return;
     }
 
+    if (this.isClosed()) {
+      return;
+    }
+
     if (this.whepType === WHEPType.Server && this.resource) {
       const answer = this.localPeer.localDescription;
       if (answer) {
@@ -252,6 +297,10 @@ export class WHEPAdapter implements Adapter {
       return;
     }
 
+    if (this.isClosed()) {
+      return;
+    }
+
     const offer = this.localPeer.localDescription;
 
     if (this.whepType === WHEPType.Client && offer) {
@@ -270,6 +319,11 @@ export class WHEPAdapter implements Adapter {
         this.resource = this.getResouceUrlFromHeaders(response.headers);
         this.log('WHEP Resource', this.resource);
         const answer = await response.text();
+        // Teardown may have happened while awaiting the answer body; do not
+        // apply the remote description to a closed peer.
+        if (this.isClosed()) {
+          return;
+        }
         await this.localPeer.setRemoteDescription({
           type: 'answer',
           sdp: answer

--- a/src/index.ts
+++ b/src/index.ts
@@ -425,7 +425,13 @@ export class WebRTCPlayer extends EventEmitter {
   stop() {
     clearInterval(this.statsInterval);
     this.stopVideoHealthMonitor();
-    this.peer.close();
+    // Closing the peer connection flips its signalingState to 'closed', which
+    // the adapter observes to short-circuit any in-flight SDP exchange started
+    // before the connection was established (see WHEPAdapter). Guard against a
+    // peer that was never set up (e.g. stop()/destroy() called before load()).
+    if (typeof this.peer.close === 'function') {
+      this.peer.close();
+    }
     this.videoElement.srcObject = null;
     this.videoElement.load();
   }


### PR DESCRIPTION
## Summary
- Implements #106: when `destroy()` (via `stop()`) is called before the WHEP connection is established, the in-flight SDP exchange could later call `setRemoteDescription`/`setLocalDescription` on a peer whose `signalingState` is now `closed`, throwing `InvalidStateError`. This guards every in-flight signaling step so teardown aborts cleanly.

## Changes
- `src/adapters/WHEPAdapter.ts`:
  - New internal `closed` flag and `isClosed()` helper (`this.closed || localPeer.signalingState === 'closed'`).
  - `disconnect()` now sets `closed`, clears `waitingForCandidates`, and cancels the ICE-gathering timeout up front.
  - `initSdpExchange()` bails if closed at entry and re-checks after each async boundary (`createOffer`, `requestOffer`, `createAnswer`) before touching the peer.
  - `onIceGatheringStateChange`, `onIceGatheringTimeout`, and `onDoneWaitingForCandidates` short-circuit when closed (so a late ICE timeout after destroy is a no-op).
  - `sendOffer()`/`sendAnswer()` short-circuit when closed, and `sendOffer()` re-checks after awaiting the answer body before `setRemoteDescription`.
  - `connect()`'s catch swallows the error quietly when closed (an error from a torn-down exchange is expected, not a real connect error).
- `src/index.ts`: `stop()` guards `this.peer.close()` so calling `stop()`/`destroy()` before `load()` (placeholder peer) does not throw; documents that closing the peer is the signal the adapter observes.

Public-API note: no public API change. All additions are internal guards; the `Adapter` interface is unchanged.

## Test plan
- Reasoned correctness (no unit-test suite in repo): the reliable signal is that `stop()`/`destroy()` calls `peer.close()`, flipping `signalingState` to `closed`. Every signaling continuation (both the direct client-offer path and the fallback server-offer path, plus the ICE timeout/gathering callbacks) now checks `isClosed()` at each async re-entry point before invoking any RTCPeerConnection method, so none can run against a closed peer.
- `npx prettier --check` on `WHEPAdapter.ts`: clean. `src/index.ts` prettier warning is the pre-existing `setupPeer` line only (verified via `prettier` diff), untouched here.
- `npm run typecheck`: passes.
- `npm run build:demo`: builds successfully, bundles real source.
- Caveats (pre-existing, unrelated): full `npm run build` is broken on `main` by a pre-existing `@parcel/*` lockfile drift (being fixed in PR #98); `npm run pretty`/`lint` report one pre-existing prettier violation on the `setupPeer` line of `src/index.ts` present on `main`, left untouched. Repo has no unit-test suite (`npm test` is a stub).

Closes #106

🤖 Automated via WebRTC daily-backlog-pr skill