### PR TITLE
feat: expose connection status/readyState and a 'connected' event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ enum Message {
   INITIAL_CONNECTION_FAILED = 'initial-connection-failed',
   RECONNECTION_FAILED = 'reconnection-failed',
   CONNECT_ERROR = 'connect-error',
+  CONNECTED = 'connected',
   PLAYER_MUTED = 'player-muted',
   PLAYER_UNMUTED = 'player-unmuted',
   VIDEO_RECOVERY_ATTEMPT = 'video-recovery-attempt',
@@ -37,6 +38,17 @@ export interface AvailableTrack {
   id: string; // MediaStreamTrack id
   mid: string | null; // negotiated transceiver mid, if available
   track: MediaStreamTrack;
+}
+
+// Lifecycle of the player's peer connection, exposed through the readonly
+// `readyState` property. Callers can use it (together with the `connected`
+// event) to defer teardown until the connection has been established.
+export enum WebRTCPlayerState {
+  New = 'new',
+  Connecting = 'connecting',
+  Connected = 'connected',
+  Failed = 'failed',
+  Closed = 'closed'
 }
 
 export interface MediaConstraints {
@@ -129,6 +141,7 @@ export class WebRTCPlayer extends EventEmitter {
   private availableTracks: AvailableTrack[] = [];
   private authToken?: string = undefined;
   private proxyUrl?: string = undefined;
+  private connectionState: WebRTCPlayerState = WebRTCPlayerState.New;
 
   constructor(opts: WebRTCPlayerOptions) {
     super();
@@ -199,6 +212,22 @@ export class WebRTCPlayer extends EventEmitter {
     });
   }
 
+  // Current lifecycle state of the peer connection. Read-only; transitions are
+  // driven internally as the connection progresses.
+  get readyState(): WebRTCPlayerState {
+    return this.connectionState;
+  }
+
+  private setConnectionState(state: WebRTCPlayerState) {
+    if (this.connectionState === state) {
+      return;
+    }
+    this.connectionState = state;
+    if (state === WebRTCPlayerState.Connected) {
+      this.emit(Message.CONNECTED);
+    }
+  }
+
   async load(channelUrl: URL, authKey: string | undefined = undefined) {
     this.channelUrl = channelUrl;
     this.authKey = authKey;
@@ -223,6 +252,7 @@ export class WebRTCPlayer extends EventEmitter {
       this.peer && this.peer.close();
 
       if (this.reconnectAttemptsLeft <= 0) {
+        this.setConnectionState(WebRTCPlayerState.Failed);
         this.emit(Message.RECONNECTION_FAILED);
         this.error('Connection failed, reconnecting failed');
         return;
@@ -235,6 +265,7 @@ export class WebRTCPlayer extends EventEmitter {
       this.reconnectAttemptsLeft--;
     } else if (this.peer.connectionState === 'connected') {
       this.log('Connected');
+      this.setConnectionState(WebRTCPlayerState.Connected);
       this.emit(Message.PEER_CONNECTION_CONNECTED);
       this.reconnectAttemptsLeft = this.configuredReconnectAttempts;
       this.reconnectAttemptsLeft = RECONNECT_ATTEMPTS;
@@ -555,6 +586,7 @@ export class WebRTCPlayer extends EventEmitter {
   }
 
   private async connect() {
+    this.setConnectionState(WebRTCPlayerState.Connecting);
     this.setupPeer();
 
     if (this.adapterType !== 'custom') {
@@ -628,6 +660,7 @@ export class WebRTCPlayer extends EventEmitter {
     }
     this.videoElement.srcObject = null;
     this.videoElement.load();
+    this.setConnectionState(WebRTCPlayerState.Closed);
   }
 
   destroy() {


### PR DESCRIPTION
## Summary
- Implements #107: adds a readonly `readyState` property reflecting the peer-connection lifecycle and emits a `connected` event when the connection is established, so callers can defer `destroy()`/`stop()` until ready (relates to #106).

## Changes
- `src/index.ts`:
  - New exported `WebRTCPlayerState` enum (`new` | `connecting` | `connected` | `failed` | `closed`).
  - New readonly getter `readyState: WebRTCPlayerState` on `WebRTCPlayer`.
  - New `connected` event (added to the existing `Message` enum, emitted via the same `EventEmitter` pattern) fired on the transition into the connected state.
  - Internal `setConnectionState()` drives transitions: `connecting` at the start of `connect()`, `connected` when `peer.connectionState === 'connected'` (alongside the existing `peer-connection-connected` event, which is kept for backward compatibility), `failed` when reconnect attempts are exhausted, `closed` in `stop()`. The `connected` event only fires on an actual transition (no duplicate emits).

Public-API note (additive): `readyState`, the `WebRTCPlayerState` enum, and the `connected` event are NEW public API. They are purely additive — no existing property, method, or event changed or was removed (the pre-existing `peer-connection-connected` event still fires). Flagged here as additive public-API surface for release notes.

## Test plan
- Reasoned correctness (no unit-test suite in repo): `readyState` starts at `new`; `load()` -> `connect()` sets `connecting`; the peer `connectionstatechange` handler sets `connected` (emitting `connected` once) or `failed`; `stop()`/`destroy()` sets `closed`. `setConnectionState` guards against duplicate transitions so `connected` fires exactly once per successful connect.
- `npm run typecheck`: passes.
- `npm run build:demo`: builds successfully, bundles real source.
- Caveats (pre-existing, unrelated): full `npm run build` is broken on `main` by a pre-existing `@parcel/*` lockfile drift (being fixed in PR #98); `npm run pretty`/`lint` report one pre-existing prettier violation on the `setupPeer` line of `src/index.ts` present on `main` (verified via `prettier` diff), left untouched. Repo has no unit-test suite (`npm test` is a stub).

Closes #107

🤖 Automated via WebRTC daily-backlog-pr skill